### PR TITLE
55 Update chronicle model to return chronicle.sts with a list of storytellers

### DIFF
--- a/app/models/chronicle.rb
+++ b/app/models/chronicle.rb
@@ -3,7 +3,11 @@ class Chronicle < ActiveRecord::Base
 	
 	has_many :characters
 	has_many :user_administers_chronicles
-	has_many :users, :through => :user_administers_chronicles
+	has_many :users, :through => :user_administers_chronicles, as: :storytellers
 	has_many :chronicle_allows_character_types
 	has_many :character_types, :through => :chronicle_allows_character_types
+
+	def sts
+		self.users
+	end
 end


### PR DESCRIPTION
Closes #55. Call .sts on an instance of Chronicle and it should return the list of storyteller user objects. User creating the chronicle is auto-added at time of chronicle creation.
