### PR TITLE
Fix typecasting error w/ behaviors; also set moralities by default to 7

### DIFF
--- a/db/migrate/20150823024725_change_behavior_ids_to_integers.rb
+++ b/db/migrate/20150823024725_change_behavior_ids_to_integers.rb
@@ -1,0 +1,8 @@
+class ChangeBehaviorIdsToIntegers < ActiveRecord::Migration
+  def change
+  	remove_column :characters, :behavior_primary_id
+  	remove_column :characters, :behavior_secondary_id
+  	add_column :characters, :behavior_primary_id, :integer
+  	add_column :characters, :behavior_secondary_id, :integer
+  end
+end

--- a/db/migrate/20150823025145_set_default_morality.rb
+++ b/db/migrate/20150823025145_set_default_morality.rb
@@ -1,0 +1,5 @@
+class SetDefaultMorality < ActiveRecord::Migration
+  def change
+  	change_column :characters, :morality, :integer, default: 7
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150822064337) do
+ActiveRecord::Schema.define(version: 20150823025145) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,14 @@ ActiveRecord::Schema.define(version: 20150822064337) do
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.integer  "value",        default: 1
+  end
+
+  create_table "character_has_merit", force: :cascade do |t|
+    t.integer "character_id"
+    t.integer "merit_id"
+    t.string  "specification"
+    t.text    "description"
+    t.integer "rating"
   end
 
   create_table "character_has_merits", force: :cascade do |t|
@@ -127,15 +135,13 @@ ActiveRecord::Schema.define(version: 20150822064337) do
     t.integer  "lineage_id"
     t.integer  "affiliation_id"
     t.string   "sublineage"
-    t.string   "behavior_primary_id"
-    t.string   "behavior_secondary_id"
     t.integer  "size"
     t.integer  "defense"
     t.integer  "initiative_mod"
     t.integer  "armor_ballistic"
     t.integer  "speed"
     t.integer  "power_stat",            default: 1
-    t.integer  "morality"
+    t.integer  "morality",              default: 7
     t.integer  "health",                default: 6
     t.integer  "willpower",             default: 2
     t.integer  "max_resource",          default: 10
@@ -155,7 +161,6 @@ ActiveRecord::Schema.define(version: 20150822064337) do
     t.integer  "armor_general"
     t.text     "st_notes"
     t.text     "printed_notes"
-    t.integer  "status",                default: 0
     t.integer  "intelligence",          default: 1
     t.integer  "wits",                  default: 1
     t.integer  "resolve",               default: 1
@@ -189,6 +194,9 @@ ActiveRecord::Schema.define(version: 20150822064337) do
     t.integer  "socialize",             default: 0
     t.integer  "streetwise",            default: 0
     t.integer  "subterfuge",            default: 0
+    t.integer  "status",                default: 0
+    t.integer  "behavior_primary_id"
+    t.integer  "behavior_secondary_id"
   end
 
   create_table "chronicle_allows_character_types", force: :cascade do |t|


### PR DESCRIPTION
Closes #97.

Apparently at some point behavior_primary_id and behavior_secondary_id on characters got set to a string instead of an integer and was causing problems; this has now been fixed. Also, since there was no default for character moralities, if they did not set their morality it would cause a show error. To fix this I defaulted it to 7.
