### PR TITLE
Character and Chronicle Deletion

### DIFF
--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -95,8 +95,10 @@ class CharactersController < ApplicationController
 		end
 	end
 
-	def delete
+	def destroy
 		@character = Character.find_by_id(params[:id])
+		@character.delete
+		redirect_to characters_path
 	end
 
 	private

--- a/app/controllers/chronicles_controller.rb
+++ b/app/controllers/chronicles_controller.rb
@@ -57,7 +57,6 @@ class ChroniclesController < ApplicationController
 
 	def update
 		@chronicle = Chronicle.find_by_id(params[:id])
-		puts params[:chronicle]
 		if @chronicle.update!(chronicles_params)
 			flash[:success] = "The chronicle has been updated."
 			redirect_to edit_chronicle_path
@@ -65,6 +64,12 @@ class ChroniclesController < ApplicationController
 			flash[:error] = "There was an error saving your chronicle."
 			redirect_to edit_chronicle_path
 		end
+	end
+
+	def destroy
+		@chronicle = Chronicle.find_by_id(params[:id])
+		@chronicle.delete
+		redirect_to chronicles_path
 	end
 
 	private

--- a/app/views/characters/index.slim
+++ b/app/views/characters/index.slim
@@ -13,6 +13,7 @@
 						th Lineage
 						th Status
 						th
+						th
 				tbody
 					- @characters.each do |character|
 						tr
@@ -29,6 +30,9 @@
 							td
 								- if character.status == 0 || character.chronicle.sts.include?(current_user)
 									= link_to "Edit", edit_character_path(character)
+							td
+								= form_tag(character_path(character), method: 'DELETE') do
+									= button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this character?");', class: 'button tiny alert'
 
 		- else
 			| You don't have any characters yet! Try <a href="#{new_character_path}">making one now</a>!

--- a/app/views/chronicles/index.slim
+++ b/app/views/chronicles/index.slim
@@ -8,11 +8,16 @@
 				thead
 					tr 
 						th Name
+						th
 				tbody
 					- @chronicles.each do |chronicle|
 						tr
 							td
 								= link_to chronicle.title, chronicle_path(id: chronicle.id)
+							td
+								- if chronicle.sts.first == current_user
+									= form_tag(chronicle_path(chronicle), method: 'DELETE') do
+										= button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to permanently delete this chronicle?");', class: 'button tiny alert'
 							
 		- else
 			| You don't have any chronicles yet! Try <a href="#{new_chronicle_path}">making one now</a>!

--- a/app/views/chronicles/show.slim
+++ b/app/views/chronicles/show.slim
@@ -16,11 +16,13 @@
       table#character_index_table
         thead
           tr
-        	  th Name
-        	  th Player
-        	  th Affiliation
-        	  th Lineage
-        	  th Status
+            th Name
+            th Player
+            th Affiliation
+            th Lineage
+            th Status
+            th 
+            th 
         tbody
           - @characters.each do |character|
             tr
@@ -34,5 +36,11 @@
                 = Lineage.find_by(id: character.lineage_id).name
               td
                 = get_status(character.status)
+              td
+                = link_to "Edit", edit_character_path(character)
+              td
+                - if character.user(current_user)
+                  = form_tag(character_path(character), method: 'DELETE') do
+                    = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this character?");', class: 'button tiny alert'
     - else
      | There are no characters in this chronicle yet!

--- a/app/views/chronicles/show.slim
+++ b/app/views/chronicles/show.slim
@@ -41,6 +41,6 @@
               td
                 - if character.user(current_user)
                   = form_tag(character_path(character), method: 'DELETE') do
-                    = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this character?");', class: 'button tiny alert'
+                    = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to permanently delete this character?");', class: 'button tiny alert'
     - else
      | There are no characters in this chronicle yet!


### PR DESCRIPTION
Closes #145 

branch name is slightly misleading; also implements chronicle deletion
also added a delete button for characters that the current user owns on chronicle#show for storyteller-owned characters (such as NPCs and test characters)
