### PR TITLE
Add integrated downtime system

### DIFF
--- a/app/assets/stylesheets/chronicle.scss
+++ b/app/assets/stylesheets/chronicle.scss
@@ -13,6 +13,15 @@
     top: -.2em;
   }
 
+  .manage_games_button, .grant_experience_button, .process_downtimes_button {
+  	top: -.2em;
+  	margin-left: .5em;
+  }
+
+  h2 .button-group {
+  	display: inline-block;
+  }
+
   img {
     border: 6px solid $purple;
     border-radius: 3px;

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -116,6 +116,7 @@ class CharactersController < ApplicationController
 	def new_downtime_action
 		@character = Character.find_by_id(params[:id])
 		@downtime_action = DowntimeAction.new
+		@games = Game.where(chronicle: @character.chronicle, active: true)
 	end
 
 	def create_downtime_action

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -135,6 +135,7 @@ class CharactersController < ApplicationController
 	def edit_downtime_action
 		@character = Character.find_by_id(params[:id])
 		@downtime_action = DowntimeAction.find_by_id(params[:downtime_action_id])
+		@games = Game.where(chronicle: @character.chronicle, active: true)
 	end
 
 	def update_downtime_action
@@ -169,6 +170,6 @@ class CharactersController < ApplicationController
 	end
 
 	def downtime_actions_params
-		params.require(:downtime_action).permit(:character_id, :game_id, :title, :assets, :points_spent, :description)
+		params.require(:downtime_action).permit(:character_id, :game_id, :title, :assets, :points_spent, :description, :submitted)
 	end
 end

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -105,16 +105,19 @@ class CharactersController < ApplicationController
 
 	def downtime_actions
 		@character = Character.find_by_id(params[:id])
+		redirect_to index_path if @character.user != current_user
 		@downtime_actions = @character.downtime_actions
 	end
 
 	def downtime_action
 		@character = Character.find_by_id(params[:id])
+		redirect_to index_path if @character.user != current_user
 		@downtime_action = DowntimeAction.find_by_id(params[:downtime_action_id])
 	end
 
 	def new_downtime_action
 		@character = Character.find_by_id(params[:id])
+		redirect_to index_path if @character.user != current_user
 		@downtime_action = DowntimeAction.new
 		@games = Game.where(chronicle: @character.chronicle, active: true)
 	end
@@ -134,6 +137,7 @@ class CharactersController < ApplicationController
 
 	def edit_downtime_action
 		@character = Character.find_by_id(params[:id])
+		redirect_to index_path if @character.user != current_user
 		@downtime_action = DowntimeAction.find_by_id(params[:downtime_action_id])
 		@games = Game.where(chronicle: @character.chronicle, active: true)
 	end

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -91,7 +91,8 @@ class CharactersController < ApplicationController
 			flash[:success] = "Your changes to your character were saved."
 			redirect_to character_path(@character)
 		else
-			flash[:alert] = "There was an error saving changes to your character."
+			@error = @character.errors.messages
+			flash[:error] = @error
 			redirect_to edit_character_path(@character)
 		end
 	end
@@ -102,9 +103,71 @@ class CharactersController < ApplicationController
 		redirect_to characters_path
 	end
 
+	def downtime_actions
+		@character = Character.find_by_id(params[:id])
+		@downtime_actions = @character.downtime_actions
+	end
+
+	def downtime_action
+		@character = Character.find_by_id(params[:id])
+		@downtime_action = DowntimeAction.find_by_id(params[:downtime_action_id])
+	end
+
+	def new_downtime_action
+		@character = Character.find_by_id(params[:id])
+		@downtime_action = DowntimeAction.new
+	end
+
+	def create_downtime_action
+		@character = Character.find_by_id(params[:id])
+		@downtime_action = DowntimeAction.new(downtime_actions_params)
+		if @downtime_action.save
+			flash[:success] = "Your downtime action has been saved."
+			redirect_to character_downtime_actions_path(@character)
+		else
+			@error = @character.errors.messages
+			flash[:error] = @error
+			redirect_to character_new_downtime_action_path
+		end
+	end
+
+	def edit_downtime_action
+		@character = Character.find_by_id(params[:id])
+		@downtime_action = DowntimeAction.find_by_id(params[:downtime_action_id])
+	end
+
+	def update_downtime_action
+		@character = Character.find_by_id(params[:id])
+		@downtime_action = DowntimeAction.find_by_id(params[:downtime_action_id])
+		if @downtime_action.update_attributes(downtime_actions_params)
+			flash[:success] = "Your downtime action has been saved."
+			redirect_to character_downtime_actions_path(@character)
+		else
+			@error = @character.errors.messages
+			flash[:error] = @error
+			redirect_to character_edit_downtime_action_path(@character)
+		end
+	end
+
+	def destroy_downtime_action
+		@character = Character.find_by_id(params[:id])
+		@downtime_action = DowntimeAction.find_by_id(params[:downtime_action_id])
+		if @downtime_action.delete
+			flash[:success] = "Your downtime action was deleted."
+		else
+			@error = @character.errors.messages
+			flash[:error] = @error
+		end
+		redirect_to character_downtime_actions_path(@character)
+	end
+
 	private
 
 	def characters_params
 		params.require(:character).permit(:name, :sublineage, :max_resource, :behavior_primary_id, :behavior_secondary_id, :lineage_id, :affiliation_id, :user_id, :chronicle_id, :character_type_id, :attribs, :skills, :merits, :health, :willpower, :power_stat, :morality, :size, :speed, :armor_ballistic, :armor_general, :defense, :answer1, :answer2, :answer3, :answer4, :answer5, :answer6, :answer7, :answer8, :printed_notes, :st_notes, :misc, :intelligence, :wits, :resolve, :strength, :dexterity, :stamina, :presence, :manipulation, :composure, :academics, :computer, :crafts, :computer, :investigation, :medicine, :occult, :politics, :science, :athletics, :brawl, :drive, :firearms, :larceny, :stealth, :survival, :weaponry, :animal_ken, :empathy, :expression, :intimidation, :persuasion, :streetwise, :subterfuge, :status, :wishlist, skill_specialties_attributes: [:skill_id, :specialty, :character_id, :id, :_destroy], character_has_powers_attributes: [:character_id, :power_id, :id, :_destroy], character_has_merits_attributes: [:character_id, :merit_id, :specification, :description, :rating, :id])
+	end
+
+	def downtime_actions_params
+		params.require(:downtime_action).permit(:character_id, :game_id, :title, :assets, :points_spent, :description)
 	end
 end

--- a/app/controllers/chronicles_controller.rb
+++ b/app/controllers/chronicles_controller.rb
@@ -151,11 +151,20 @@ class ChroniclesController < ApplicationController
 	end
 
 	def show_downtime_action
+		@chronicle = Chronicle.find_by_id(params[:id])
 		@downtime_action = DowntimeAction.find_by_id(params[:downtime_action_id])
 	end
 
 	def process_downtime_action
-
+		@chronicle = Chronicle.find_by_id(params[:id])
+		@downtime_action = DowntimeAction.find_by_id(params[:downtime_action_id])
+		if @downtime_action.update_attributes(response: params[:response])
+			flash[:success] = "Downtime response saved."
+		else
+			@error = @character.errors.messages
+			flash[:error] = @error
+		end
+		redirect_to show_downtime_action_path(@chronicle, @downtime_action)
 	end
 
 	def games
@@ -213,6 +222,6 @@ class ChroniclesController < ApplicationController
 	end
 
 	def games_params
-		params.require(:game).permit(:title, :game_number, :chronicle_id)
+		params.require(:game).permit(:title, :game_number, :chronicle_id, :active)
 	end
 end

--- a/app/controllers/chronicles_controller.rb
+++ b/app/controllers/chronicles_controller.rb
@@ -140,9 +140,79 @@ class ChroniclesController < ApplicationController
 		redirect_to xp_records_path(params[:id])
 	end
 
+	def downtime_actions
+		@chronicle = Chronicle.find_by_id(params[:id])
+		@characters = @chronicle.characters.collect {|c| c.id }
+		if @characters.present?
+			@downtime_actions = DowntimeAction.where(character_id: @characters)
+		else
+			@downtime_actions = []
+		end
+	end
+
+	def show_downtime_action
+		@downtime_action = DowntimeAction.find_by_id(params[:downtime_action_id])
+	end
+
+	def process_downtime_action
+
+	end
+
+	def games
+		@chronicle = Chronicle.find_by_id(params[:id])
+		@games = Game.where(chronicle: params[:id])
+	end
+
+	def new_game
+		@chronicle = Chronicle.find_by_id(params[:id])
+		@game = Game.new
+	end
+
+	def create_game
+		@chronicle = Chronicle.find_by_id(params[:id])
+		@game = Game.new(games_params)
+		if @game.save
+			flash[:success] = "Your game was added to #{@chronicle.title}."
+			redirect_to games_path(@chronicle)
+		else
+			@error = @character.errors.messages
+			flash[:error] = @error
+			redirect_to new_game_path(@chronicle)
+		end
+	end
+
+	def edit_game
+		@chronicle = Chronicle.find_by_id(params[:id])
+		@game = Game.find_by_id(params[:game_id])
+	end
+
+	def update_game
+		@chronicle = Chronicle.find_by_id(params[:id])
+		@game = Game.find_by_id(params[:game_id])
+		if @game.update_attributes(games_params)
+			flash[:success] = "Your game was updated."
+			redirect_to games_path(@chronicle)
+		else
+			@error = @character.errors.messages
+			flash[:error] = @error
+			redirect_to edit_game_path(@chronicle, @game)
+		end
+	end
+
+	def destroy_game
+		@game = Game.find_by_id(params[:game_id])
+		@chronicle = Chronicle.find_by_id(params[:id])
+		@game.delete
+		redirect_to games_path(@chronicle)
+	end
+
 	private
 
 	def chronicles_params
 		params.require(:chronicle).permit(:title, chronicle_has_character_types_attributes: [:character_type_id, :chronicle_id, :id], user_administers_chronicles_attributes: [:user_id, :chronicle_id, :id])
+	end
+
+	def games_params
+		params.require(:game).permit(:title, :game_number, :chronicle_id)
 	end
 end

--- a/app/controllers/chronicles_controller.rb
+++ b/app/controllers/chronicles_controller.rb
@@ -142,12 +142,8 @@ class ChroniclesController < ApplicationController
 
 	def downtime_actions
 		@chronicle = Chronicle.find_by_id(params[:id])
-		@characters = @chronicle.characters.collect {|c| c.id }
-		if @characters.present?
-			@downtime_actions = DowntimeAction.where(character_id: @characters)
-		else
-			@downtime_actions = []
-		end
+		@game = Game.find_by_id(params[:game_id])
+		@downtime_actions = @game.downtime_actions
 	end
 
 	def show_downtime_action
@@ -157,20 +153,21 @@ class ChroniclesController < ApplicationController
 
 	def process_downtime_action
 		@chronicle = Chronicle.find_by_id(params[:id])
+		@game = Game.find_by_id(params[:game_id])
 		@downtime_action = DowntimeAction.find_by_id(params[:downtime_action_id])
-		if @downtime_action.update_attributes(response: params[:response])
+		if @downtime_action.update_attributes(response: params[:downtime_action][:response])
 			flash[:success] = "Downtime response saved."
 		else
 			@error = @character.errors.messages
 			flash[:error] = @error
 		end
-		redirect_to show_downtime_action_path(@chronicle, @downtime_action)
+		redirect_to show_downtime_action_path(@chronicle, @game, @downtime_action)
 	end
 
 	def print_downtime_actions
 		@chronicle = Chronicle.find_by_id(params[:id])
 		@game = Game.find_by_id(params[:game_id])
-		@downtime_actions = @game.downtime_actions
+		@characters = @chronicle.characters
 	end
 
 	def games

--- a/app/controllers/chronicles_controller.rb
+++ b/app/controllers/chronicles_controller.rb
@@ -167,6 +167,12 @@ class ChroniclesController < ApplicationController
 		redirect_to show_downtime_action_path(@chronicle, @downtime_action)
 	end
 
+	def print_downtime_actions
+		@chronicle = Chronicle.find_by_id(params[:id])
+		@game = Game.find_by_id(params[:game_id])
+		@downtime_actions = @game.downtime_actions
+	end
+
 	def games
 		@chronicle = Chronicle.find_by_id(params[:id])
 		@games = Game.where(chronicle: params[:id])

--- a/app/controllers/chronicles_controller.rb
+++ b/app/controllers/chronicles_controller.rb
@@ -75,6 +75,7 @@ class ChroniclesController < ApplicationController
 
 	def xp_records
 		@chronicle = Chronicle.find_by_id(params[:id])
+		redirect_to index_path if @chronicle.sts.exclude?(current_user)
 		if @chronicle.sts.include?(current_user)
 			@characters = @chronicle.characters.collect {|c| c.id }
 			if @characters.present?
@@ -89,6 +90,7 @@ class ChroniclesController < ApplicationController
 
 	def new_xp_record
 		@chronicle = Chronicle.find_by_id(params[:id])
+		redirect_to index_path if @chronicle.sts.exclude?(current_user)
 		if @chronicle.sts.include?(current_user)
 			@characters = Character.find_by_chronicle_id(params[:id])
 			@xp_record = XpRecord.new
@@ -99,6 +101,7 @@ class ChroniclesController < ApplicationController
 
 	def new_xp_records
 		@chronicle = Chronicle.find_by_id(params[:id])
+		redirect_to index_path if @chronicle.sts.exclude?(current_user)
 		if @chronicle.sts.include?(current_user)
 			@characters = Character.where(chronicle_id: params[:id], status: 3)
 		else
@@ -142,17 +145,20 @@ class ChroniclesController < ApplicationController
 
 	def downtime_actions
 		@chronicle = Chronicle.find_by_id(params[:id])
+		redirect_to index_path if @chronicle.sts.exclude?(current_user)
 		@game = Game.find_by_id(params[:game_id])
 		@downtime_actions = @game.downtime_actions
 	end
 
 	def show_downtime_action
 		@chronicle = Chronicle.find_by_id(params[:id])
+		redirect_to index_path if @chronicle.sts.exclude?(current_user)
 		@downtime_action = DowntimeAction.find_by_id(params[:downtime_action_id])
 	end
 
 	def process_downtime_action
 		@chronicle = Chronicle.find_by_id(params[:id])
+		redirect_to index_path if @chronicle.sts.exclude?(current_user)
 		@game = Game.find_by_id(params[:game_id])
 		@downtime_action = DowntimeAction.find_by_id(params[:downtime_action_id])
 		if @downtime_action.update_attributes(response: params[:downtime_action][:response])
@@ -166,17 +172,20 @@ class ChroniclesController < ApplicationController
 
 	def print_downtime_actions
 		@chronicle = Chronicle.find_by_id(params[:id])
+		redirect_to index_path if @chronicle.sts.exclude?(current_user)
 		@game = Game.find_by_id(params[:game_id])
 		@characters = @chronicle.characters
 	end
 
 	def games
 		@chronicle = Chronicle.find_by_id(params[:id])
+		redirect_to index_path if @chronicle.sts.exclude?(current_user)
 		@games = Game.where(chronicle: params[:id])
 	end
 
 	def new_game
 		@chronicle = Chronicle.find_by_id(params[:id])
+		redirect_to index_path if @chronicle.sts.exclude?(current_user)
 		@game = Game.new
 	end
 
@@ -195,11 +204,13 @@ class ChroniclesController < ApplicationController
 
 	def edit_game
 		@chronicle = Chronicle.find_by_id(params[:id])
+		redirect_to index_path if @chronicle.sts.exclude?(current_user)
 		@game = Game.find_by_id(params[:game_id])
 	end
 
 	def update_game
 		@chronicle = Chronicle.find_by_id(params[:id])
+		redirect_to index_path if @chronicle.sts.exclude?(current_user)
 		@game = Game.find_by_id(params[:game_id])
 		if @game.update_attributes(games_params)
 			flash[:success] = "Your game was updated."

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -12,6 +12,7 @@ class Character < ActiveRecord::Base
 	has_many :merits, through: :character_has_merits
 	has_many :skill_specialties
 	has_many :xp_records
+	has_many :downtime_actions
 	belongs_to :lineage
 	belongs_to :affiliation
 	belongs_to :character_type
@@ -20,5 +21,5 @@ class Character < ActiveRecord::Base
 	belongs_to :user
 	belongs_to :chronicle
 
-	accepts_nested_attributes_for :character_has_powers, :character_has_merits, :skill_specialties, allow_destroy: true
+	accepts_nested_attributes_for :character_has_powers, :character_has_merits, :skill_specialties, :downtime_actions, allow_destroy: true
 end

--- a/app/models/chronicle.rb
+++ b/app/models/chronicle.rb
@@ -6,6 +6,7 @@ class Chronicle < ActiveRecord::Base
 	has_many :users, :through => :user_administers_chronicles, as: :storytellers
 	has_many :chronicle_allows_character_types
 	has_many :character_types, :through => :chronicle_allows_character_types
+	has_many :games
 
 	accepts_nested_attributes_for :user_administers_chronicles
 

--- a/app/models/downtime_action.rb
+++ b/app/models/downtime_action.rb
@@ -1,0 +1,6 @@
+class DowntimeAction < ActiveRecord::Base
+	validates :character_id, :game_id, :title, :points_spent, :assets, :description, presence: true
+
+	belongs_to :character
+	belongs_to :game
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,0 +1,5 @@
+class Game < ActiveRecord::Base
+	validates :title, :chronicle_id, presence: true
+	belongs_to :chronicle
+	has_many :downtime_actions
+end

--- a/app/views/characters/_downtime_action_form.slim
+++ b/app/views/characters/_downtime_action_form.slim
@@ -5,4 +5,16 @@
 = f.text_field :assets
 = f.text_area :description
 = f.hidden_field :character_id, value: @character.id
-= f.button "Save", class: 'button'
+= f.hidden_field :submitted, value: 'false'
+ul.button-group
+	li
+		= f.button "Save", class: 'button'
+	li
+		= f.button "Save and Submit", class: 'button', id: 'submit-button'
+
+javascript:
+	$('#submit-button').click(function(e) {
+		e.preventDefault();
+		$('#downtime_action_submitted').val('true');
+		$(this).parents('form').submit();
+	});

--- a/app/views/characters/_downtime_action_form.slim
+++ b/app/views/characters/_downtime_action_form.slim
@@ -1,0 +1,7 @@
+= f.text_field :title
+= f.text_field :points_spent
+= f.text_field :assets
+= f.text_area :description
+= f.hidden_field :character_id, value: @character.id
+= f.hidden_field :game_id
+= f.button "Save", class: 'button'

--- a/app/views/characters/_downtime_action_form.slim
+++ b/app/views/characters/_downtime_action_form.slim
@@ -1,7 +1,8 @@
+= f.label :game
+= collection_select(:downtime_action, :game_id, @games, :id, :title)
 = f.text_field :title
 = f.text_field :points_spent
 = f.text_field :assets
 = f.text_area :description
 = f.hidden_field :character_id, value: @character.id
-= f.hidden_field :game_id
 = f.button "Save", class: 'button'

--- a/app/views/characters/downtime_actions.slim
+++ b/app/views/characters/downtime_actions.slim
@@ -1,0 +1,21 @@
+.row.character_index_page
+	.small-12.small-centered.columns
+		h2
+			| #{@character.name}: Downtime Actions
+			= link_to "New Downtime Action", character_new_downtime_action_path(@character), class: "button create_character_button mini-button"
+		- if @downtime_actions[0]
+			table
+				tr
+					th Title
+					th Game
+					th 
+					th
+				- @downtime_actions.each do |downtime_action|
+					tr
+						th #{downtime_action.title}
+						th #{downtime_action.game.title}
+						th edit link goes here
+						th delete link goes here
+
+
+

--- a/app/views/characters/downtime_actions.slim
+++ b/app/views/characters/downtime_actions.slim
@@ -12,10 +12,16 @@
 					th
 				- @downtime_actions.each do |downtime_action|
 					tr
-						th #{downtime_action.title}
-						th #{downtime_action.game.title}
-						th edit link goes here
-						th delete link goes here
+						td #{downtime_action.title}
+						td #{downtime_action.game.title}
+						- if downtime_action.submitted
+							td colspan="2"
+								Submitted
+						- else
+							td
+								= link_to "Edit", character_edit_downtime_action_path(@character, downtime_action)
+							td
+								= link_to "Delete", character_destroy_downtime_action_path(@character, downtime_action), onClick: 'confirm("Are you sure you want to permanently delete this downtime action?"'
 
 
 

--- a/app/views/characters/edit_downtime_action.slim
+++ b/app/views/characters/edit_downtime_action.slim
@@ -1,0 +1,7 @@
+.row.character_form_page
+	.small-12.columns
+		h1
+			| Edit Downtime Action "#{@downtime_action.title}" for #{@character.name}
+
+		= form_for @downtime_action, url: {action: 'update_downtime_action'}, method: 'post' do |f|
+			= render partial: 'downtime_action_form', locals: {f: f}

--- a/app/views/characters/index.slim
+++ b/app/views/characters/index.slim
@@ -32,6 +32,8 @@
 							td
 								- if character.status == 0 || character.chronicle.sts.include?(current_user)
 									= link_to "Edit", edit_character_path(character)
+								- elsif character.status == 3
+									= link_to "Downtime Actions", character_downtime_actions_path(character)
 							td
 								= form_tag(character_path(character), method: 'DELETE') do
 									= button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to delete this character?");', class: 'button tiny alert'

--- a/app/views/characters/new_downtime_action.slim
+++ b/app/views/characters/new_downtime_action.slim
@@ -1,0 +1,7 @@
+.row.character_form_page
+	.small-12.columns
+		h1
+			| New Downtime Action for #{@character.name}
+
+		= form_for @downtime_action, url: {action: 'create_downtime_action', method: 'post'} do |f|
+			= render partial: 'downtime_action_form', locals: {f: f}

--- a/app/views/chronicles/_game_form.slim
+++ b/app/views/chronicles/_game_form.slim
@@ -1,4 +1,5 @@
 = f.text_field :title
 = f.number_field :game_number
+= f.check_box :active
 = f.hidden_field :chronicle_id, value: @chronicle.id
 = f.button "Save", class: 'button'

--- a/app/views/chronicles/_game_form.slim
+++ b/app/views/chronicles/_game_form.slim
@@ -1,0 +1,4 @@
+= f.text_field :title
+= f.number_field :game_number
+= f.hidden_field :chronicle_id, value: @chronicle.id
+= f.button "Save", class: 'button'

--- a/app/views/chronicles/downtime_actions.slim
+++ b/app/views/chronicles/downtime_actions.slim
@@ -1,0 +1,20 @@
+.row.character_index_page
+	.small-12.small-centered.columns
+		h2
+			| Downtime Actions for #{@chronicle.title}
+			= link_to "Print Downtimes", "", class: 'button mini-button'
+
+		- if @downtime_actions[0]
+			table
+				tr
+					th Character
+					th Action Title
+					th Game
+					th 
+				- @downtime_actions.each do |downtime_action|
+					tr
+						td #{downtime_action.character.name}
+						td #{downtime_action.title}
+						td #{downtime_action.game.title}
+						td
+							= link_to "Process", show_downtime_action_path(@chronicle, downtime_action)

--- a/app/views/chronicles/downtime_actions.slim
+++ b/app/views/chronicles/downtime_actions.slim
@@ -1,8 +1,8 @@
 .row.character_index_page
 	.small-12.small-centered.columns
 		h2
-			| Downtime Actions for #{@chronicle.title}
-			= link_to "Print Downtimes", "", class: 'button mini-button'
+			| Downtime Actions for #{@chronicle.title}: #{@game.title}
+			= link_to "Print Downtimes", print_downtime_actions_path(@chronicle, @game), class: 'button mini-button'
 
 		- if @downtime_actions[0]
 			table
@@ -17,4 +17,4 @@
 						td #{downtime_action.title}
 						td #{downtime_action.game.title}
 						td
-							= link_to "Process", show_downtime_action_path(@chronicle, downtime_action)
+							= link_to "Process", show_downtime_action_path(@chronicle, @game, downtime_action)

--- a/app/views/chronicles/edit_game.slim
+++ b/app/views/chronicles/edit_game.slim
@@ -2,5 +2,5 @@
 	.small-12.small-centered.columns
 		h2 Edit #{@chronicle.title}: #{@game.title}
 
-		= form_for @game, url: {action: 'update_game', method: 'post'} do |f|
+		= form_for @game, url: {action: 'update_game'} do |f|
 			= render partial: 'game_form', locals: {f: f}

--- a/app/views/chronicles/edit_game.slim
+++ b/app/views/chronicles/edit_game.slim
@@ -1,0 +1,6 @@
+.row.character_index_page
+	.small-12.small-centered.columns
+		h2 Edit #{@chronicle.title}: #{@game.title}
+
+		= form_for @game, url: {action: 'update_game', method: 'post'} do |f|
+			= render partial: 'game_form', locals: {f: f}

--- a/app/views/chronicles/edit_game.slim
+++ b/app/views/chronicles/edit_game.slim
@@ -2,5 +2,5 @@
 	.small-12.small-centered.columns
 		h2 Edit #{@chronicle.title}: #{@game.title}
 
-		= form_for @game, url: {action: 'update_game'} do |f|
+		= form_for @game, url: {action: 'update_game'}, method: 'POST' do |f|
 			= render partial: 'game_form', locals: {f: f}

--- a/app/views/chronicles/games.slim
+++ b/app/views/chronicles/games.slim
@@ -11,11 +11,14 @@
 					th Game Number
 					th
 					th
+					th
 				- @games.each do |game|
 					tr
 						td #{game.title}
 						td #{game.game_number}
 						td
 							= link_to "Edit", edit_game_path(@chronicle, game), class: 'button mini-button'
+						td
+							= link_to "Downtimes", downtime_actions_path(@chronicle, game), class: 'button mini-button'
 						td
 							= link_to "Delete", destroy_game_path(@chronicle, game), class: 'button mini-button', onClick: 'confirm("Are you sure you want to delete this game?"'

--- a/app/views/chronicles/games.slim
+++ b/app/views/chronicles/games.slim
@@ -1,0 +1,21 @@
+.row.character_index_page
+	.small-12.small-centered.columns
+		h2
+			| Games for #{@chronicle.title}
+			= link_to "New Game", new_game_path(@chronicle), class: 'button mini-button'
+
+		- if @games[0]
+			table
+				tr
+					th Game Title
+					th Game Number
+					th
+					th
+				- @games.each do |game|
+					tr
+						td #{game.title}
+						td #{game.game_number}
+						td
+							= link_to "Edit", edit_game_path(@chronicle, game), class: 'button mini-button'
+						td
+							= link_to "Delete", destroy_game_path(@chronicle, game), class: 'button mini-button', onClick: 'confirm("Are you sure you want to delete this game?"'

--- a/app/views/chronicles/new_game.slim
+++ b/app/views/chronicles/new_game.slim
@@ -2,5 +2,5 @@
 	.small-12.small-centered.columns
 		h2 New Game for #{@chronicle.title}
 
-		= form_for @game, url: {action: 'create_game', method: 'post'} do |f|
+		= form_for @game, url: {action: 'create_game'} do |f|
 			= render partial: 'game_form', locals: {f: f}

--- a/app/views/chronicles/new_game.slim
+++ b/app/views/chronicles/new_game.slim
@@ -1,0 +1,6 @@
+.row.character_index_page
+	.small-12.small-centered.columns
+		h2 New Game for #{@chronicle.title}
+
+		= form_for @game, url: {action: 'create_game', method: 'post'} do |f|
+			= render partial: 'game_form', locals: {f: f}

--- a/app/views/chronicles/print_downtime_actions.slim
+++ b/app/views/chronicles/print_downtime_actions.slim
@@ -1,0 +1,12 @@
+.row.character_index_page
+	.small-12.small-centered.columns
+		- @characters.each do |character|
+			- if character.downtime_actions.where(game: @game).present?
+				- downtime_actions = character.downtime_actions.where(game: @game)
+				h2 #{character.name}
+
+				dl
+					- downtime_actions.each do |downtime_action|
+						dt #{downtime_action.title}
+						dd #{downtime_action.response}
+

--- a/app/views/chronicles/show.slim
+++ b/app/views/chronicles/show.slim
@@ -2,9 +2,15 @@
   .small-12.small-centered.columns
     h2
       = @chronicle.title
-      = link_to "Edit Chronicle", edit_chronicle_path(id: @chronicle.id), class: "button edit_chronicle_button mini-button" 
-      = link_to "Grant Experience", new_xp_records_path(@chronicle), class: 'button mini-button'
-      = link_to "Manage Games", games_path(@chronicle), class: 'button mini-button'
+      ul.button-group
+        li
+          = link_to "Edit Chronicle", edit_chronicle_path(id: @chronicle.id), class: "button edit_chronicle_button mini-button" 
+        li
+          = link_to "Grant Experience", new_xp_records_path(@chronicle), class: 'button mini-button grant_experience_button'
+        li
+          = link_to "Manage Games", games_path(@chronicle), class: 'button mini-button manage_games_button'
+        li
+          = link_to "Process Downtimes", downtime_actions_path(@chronicle), class: 'button mini-button process_downtimes_button'
     h3
     | Current Storytellers: 
     - if @chronicle.sts

--- a/app/views/chronicles/show.slim
+++ b/app/views/chronicles/show.slim
@@ -9,8 +9,6 @@
           = link_to "Grant Experience", new_xp_records_path(@chronicle), class: 'button mini-button grant_experience_button'
         li
           = link_to "Manage Games", games_path(@chronicle), class: 'button mini-button manage_games_button'
-        li
-          = link_to "Process Downtimes", downtime_actions_path(@chronicle), class: 'button mini-button process_downtimes_button'
     h3
     | Current Storytellers: 
     - if @chronicle.sts

--- a/app/views/chronicles/show.slim
+++ b/app/views/chronicles/show.slim
@@ -2,7 +2,9 @@
   .small-12.small-centered.columns
     h2
       = @chronicle.title
-      = link_to "Edit Chronicle", edit_chronicle_path(id: @chronicle.id), class: "button edit_chronicle_button mini-button"  
+      = link_to "Edit Chronicle", edit_chronicle_path(id: @chronicle.id), class: "button edit_chronicle_button mini-button" 
+      = link_to "Grant Experience", new_xp_records_path(@chronicle), class: 'button mini-button'
+      = link_to "Manage Games", games_path(@chronicle), class: 'button mini-button'
     h3
     | Current Storytellers: 
     - if @chronicle.sts

--- a/app/views/chronicles/show_downtime_action.slim
+++ b/app/views/chronicles/show_downtime_action.slim
@@ -17,7 +17,6 @@
 
 		h3 Storyteller Response
 
-		= form_tag(process_downtime_action_path(@chronicle, @downtime_action)) do
-			= label_tag :response
-			= text_field_tag :response, @downtime_action.response
-			= button_tag "Submit", class: 'button, mini-button'
+		= form_for @downtime_action, url: {action: 'process_downtime_action'}, method: 'post' do |f|
+			= f.text_field :response
+			= f.button "Submit", class: 'button, mini-button'

--- a/app/views/chronicles/show_downtime_action.slim
+++ b/app/views/chronicles/show_downtime_action.slim
@@ -1,0 +1,23 @@
+.row.character_index_page
+	.small-12.small-centered.columns
+		h2
+			| #{@downtime_action.character.name}: #{@downtime_action.title}
+
+		dl
+			dt Title: 
+			dd #{@downtime_action.title}
+			dt Game: 
+			dd #{@downtime_action.game.title}
+			dt Points Spent: 
+			dd #{@downtime_action.points_spent}
+			dt Assets: 
+			dd #{@downtime_action.assets}
+			dt Description
+			dd #{@downtime_action.description}
+
+		h3 Storyteller Response
+
+		= form_tag(process_downtime_action_path(@chronicle, @downtime_action)) do
+			= label_tag :response
+			= text_field_tag :response, @downtime_action.response
+			= button_tag "Submit", class: 'button, mini-button'

--- a/app/views/chronicles/show_downtime_action.slim
+++ b/app/views/chronicles/show_downtime_action.slim
@@ -1,5 +1,6 @@
 .row.character_index_page
 	.small-12.small-centered.columns
+
 		h2
 			| #{@downtime_action.character.name}: #{@downtime_action.title}
 
@@ -19,4 +20,4 @@
 
 		= form_for @downtime_action, url: {action: 'process_downtime_action'}, method: 'post' do |f|
 			= f.text_field :response
-			= f.button "Submit", class: 'button, mini-button'
+			= f.button "Save", class: 'button mini-button'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,25 @@ Rails.application.routes.draw do
   post 'chronicles/:id/xp_records/new_multiple', to: 'chronicles#create_xp_records', as: :create_xp_records
   delete 'chronicles/:id/xp_records/:xp_record_id', to: 'chronicles#destroy_xp_record', as: :destroy_xp_record
 
+  get 'chronicles/:id/downtime_actions', to: 'chronicles#downtime_actions', as: :downtime_actions
+  get 'chronicles/:id/downtime_actions/:downtime_action_id', to: 'chronicles#show_downtime_action', as: :show_downtime_action
+  post 'chronicles/:id/downtime_actions/:downtime_action_id', to: 'chronicles#process_downtime_action', as: :process_downtime_action
+
+  get 'chronicles/:id/games', to: 'chronicles#games', as: :games
+  get 'chronicles/:id/games/new', to: 'chronicles#new_game', as: :new_game
+  post 'chronicles/:id/game/new', to: 'chronicles#create_game', as: :create_game
+  get 'chronicles/:id/game/:game_id/edit', to: 'chronicles#edit_game', as: :edit_game
+  post 'chronicles/:id/game/:game_id/edit', to: 'chronicles#update_game', as: :update_game
+  delete 'chronicles/:id/game/:game_id', to: 'chronicles#destroy_game', as: :destroy_game
+
+  get 'characters/:id/downtime_actions', to: 'characters#downtime_actions', as: :character_downtime_actions
+  get 'characters/:id/downtime_action/new', to: 'characters#new_downtime_action', as: :character_new_downtime_action
+  get 'characters/:id/downtime_action/:downtime_action_id', to: 'characters#downtime_action', as: :character_downtime_action
+  get 'characters/:id/edit_downtime_action', to: 'characters#edit_downtime_action', as: :character_edit_downtime_action
+  post 'characters/:id/downtime_action/new', to: 'characters#create_downtime_action', as: :character_create_downtime_action
+  post 'characters/:id/downtime_action/:downtime_action_id/edit', to: 'characters#update_downtime_action', as: :character_update_downtime_action
+  delete 'characters/:id/downtime_action/:downtime_action_id', to: 'characters#destroy_downtime_action', as: :character_destroy_downtime_action
+
   namespace :admin do
     resources :character_types
     resources :attributes
@@ -41,54 +60,4 @@ Rails.application.routes.draw do
     resources :affiliations
     resources :merits
   end
-
-
-  # Example of regular route:
-  #   get 'products/:id' => 'catalog#view'
-
-  # Example of named route that can be invoked with purchase_url(id: product.id)
-  #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
-
-  # Example resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Example resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Example resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Example resource route with more complex sub-resources:
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', on: :collection
-  #     end
-  #   end
-
-  # Example resource route with concerns:
-  #   concern :toggleable do
-  #     post 'toggle'
-  #   end
-  #   resources :posts, concerns: :toggleable
-  #   resources :photos, concerns: :toggleable
-
-  # Example resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,11 +39,12 @@ Rails.application.routes.draw do
   get 'chronicles/:id/game/:game_id/edit', to: 'chronicles#edit_game', as: :edit_game
   post 'chronicles/:id/game/:game_id/edit', to: 'chronicles#update_game', as: :update_game
   delete 'chronicles/:id/game/:game_id', to: 'chronicles#destroy_game', as: :destroy_game
+  get 'chronicles/:id/game/:game_id/downtime_actions/print_all', to: 'chronicles#print_downtime_actions', as: :print_downtime_actions
 
   get 'characters/:id/downtime_actions', to: 'characters#downtime_actions', as: :character_downtime_actions
   get 'characters/:id/downtime_action/new', to: 'characters#new_downtime_action', as: :character_new_downtime_action
   get 'characters/:id/downtime_action/:downtime_action_id', to: 'characters#downtime_action', as: :character_downtime_action
-  get 'characters/:id/edit_downtime_action', to: 'characters#edit_downtime_action', as: :character_edit_downtime_action
+  get 'characters/:id/downtime_action/:downtime_action_id/edit', to: 'characters#edit_downtime_action', as: :character_edit_downtime_action
   post 'characters/:id/downtime_action/new', to: 'characters#create_downtime_action', as: :character_create_downtime_action
   post 'characters/:id/downtime_action/:downtime_action_id/edit', to: 'characters#update_downtime_action', as: :character_update_downtime_action
   delete 'characters/:id/downtime_action/:downtime_action_id', to: 'characters#destroy_downtime_action', as: :character_destroy_downtime_action

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,9 +29,10 @@ Rails.application.routes.draw do
   post 'chronicles/:id/xp_records/new_multiple', to: 'chronicles#create_xp_records', as: :create_xp_records
   delete 'chronicles/:id/xp_records/:xp_record_id', to: 'chronicles#destroy_xp_record', as: :destroy_xp_record
 
-  get 'chronicles/:id/downtime_actions', to: 'chronicles#downtime_actions', as: :downtime_actions
-  get 'chronicles/:id/downtime_actions/:downtime_action_id', to: 'chronicles#show_downtime_action', as: :show_downtime_action
-  post 'chronicles/:id/downtime_actions/:downtime_action_id', to: 'chronicles#process_downtime_action', as: :process_downtime_action
+  get 'chronicles/:id/game/:game_id/downtime_actions/print_all', to: 'chronicles#print_downtime_actions', as: :print_downtime_actions
+  get 'chronicles/:id/game/:game_id/downtime_actions', to: 'chronicles#downtime_actions', as: :downtime_actions
+  get 'chronicles/:id/game/:game_id/downtime_actions/:downtime_action_id', to: 'chronicles#show_downtime_action', as: :show_downtime_action
+  post 'chronicles/:id/game/:game_id/downtime_actions/:downtime_action_id', to: 'chronicles#process_downtime_action', as: :process_downtime_action
 
   get 'chronicles/:id/games', to: 'chronicles#games', as: :games
   get 'chronicles/:id/games/new', to: 'chronicles#new_game', as: :new_game
@@ -39,7 +40,6 @@ Rails.application.routes.draw do
   get 'chronicles/:id/game/:game_id/edit', to: 'chronicles#edit_game', as: :edit_game
   post 'chronicles/:id/game/:game_id/edit', to: 'chronicles#update_game', as: :update_game
   delete 'chronicles/:id/game/:game_id', to: 'chronicles#destroy_game', as: :destroy_game
-  get 'chronicles/:id/game/:game_id/downtime_actions/print_all', to: 'chronicles#print_downtime_actions', as: :print_downtime_actions
 
   get 'characters/:id/downtime_actions', to: 'characters#downtime_actions', as: :character_downtime_actions
   get 'characters/:id/downtime_action/new', to: 'characters#new_downtime_action', as: :character_new_downtime_action

--- a/db/migrate/20150826195849_add_downtime_tables.rb
+++ b/db/migrate/20150826195849_add_downtime_tables.rb
@@ -1,0 +1,18 @@
+class AddDowntimeTables < ActiveRecord::Migration
+  def change
+  	create_table :downtime_actions do |t|
+  		t.integer :character_id
+  		t.integer :game_id
+  		t.string :title
+  		t.string :points_spent
+  		t.string :assets
+  		t.text :description
+  	end
+
+  	create_table :games do |t|
+  		t.integer :chronicle_id
+  		t.integer :game_number
+  		t.string :title
+  	end
+  end
+end

--- a/db/migrate/20150826201346_add_response_column_to_downtimes.rb
+++ b/db/migrate/20150826201346_add_response_column_to_downtimes.rb
@@ -1,0 +1,5 @@
+class AddResponseColumnToDowntimes < ActiveRecord::Migration
+  def change
+  	add_column :downtime_actions, :response, :text
+  end
+end

--- a/db/migrate/20150827015526_add_active_field_to_game.rb
+++ b/db/migrate/20150827015526_add_active_field_to_game.rb
@@ -1,0 +1,5 @@
+class AddActiveFieldToGame < ActiveRecord::Migration
+  def change
+  	add_column :games, :active, :boolean, default: false
+  end
+end

--- a/db/migrate/20150827155956_add_submitted_column_to_downtime_action.rb
+++ b/db/migrate/20150827155956_add_submitted_column_to_downtime_action.rb
@@ -1,0 +1,5 @@
+class AddSubmittedColumnToDowntimeAction < ActiveRecord::Migration
+  def change
+  	add_column :downtime_actions, :submitted, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150827015526) do
+ActiveRecord::Schema.define(version: 20150827155956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,14 +49,6 @@ ActiveRecord::Schema.define(version: 20150827015526) do
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.integer  "value",        default: 1
-  end
-
-  create_table "character_has_merit", force: :cascade do |t|
-    t.integer "character_id"
-    t.integer "merit_id"
-    t.string  "specification"
-    t.text    "description"
-    t.integer "rating"
   end
 
   create_table "character_has_merits", force: :cascade do |t|
@@ -221,6 +213,7 @@ ActiveRecord::Schema.define(version: 20150827015526) do
     t.string  "assets"
     t.text    "description"
     t.text    "response"
+    t.boolean "submitted",    default: false
   end
 
   create_table "games", force: :cascade do |t|
@@ -286,10 +279,6 @@ ActiveRecord::Schema.define(version: 20150827015526) do
     t.integer  "skill_category_id"
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
-  end
-
-  create_table "statuses", force: :cascade do |t|
-    t.string "name"
   end
 
   create_table "user_administers_chronicles", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150826201346) do
+ActiveRecord::Schema.define(version: 20150827015526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,14 @@ ActiveRecord::Schema.define(version: 20150826201346) do
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.integer  "value",        default: 1
+  end
+
+  create_table "character_has_merit", force: :cascade do |t|
+    t.integer "character_id"
+    t.integer "merit_id"
+    t.string  "specification"
+    t.text    "description"
+    t.integer "rating"
   end
 
   create_table "character_has_merits", force: :cascade do |t|
@@ -219,6 +227,7 @@ ActiveRecord::Schema.define(version: 20150826201346) do
     t.integer "chronicle_id"
     t.integer "game_number"
     t.string  "title"
+    t.boolean "active",       default: false
   end
 
   create_table "lineages", force: :cascade do |t|
@@ -277,6 +286,10 @@ ActiveRecord::Schema.define(version: 20150826201346) do
     t.integer  "skill_category_id"
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
+  end
+
+  create_table "statuses", force: :cascade do |t|
+    t.string "name"
   end
 
   create_table "user_administers_chronicles", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150824211433) do
+ActiveRecord::Schema.define(version: 20150826201346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -203,6 +203,22 @@ ActiveRecord::Schema.define(version: 20150824211433) do
     t.string   "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "downtime_actions", force: :cascade do |t|
+    t.integer "character_id"
+    t.integer "game_id"
+    t.string  "title"
+    t.string  "points_spent"
+    t.string  "assets"
+    t.text    "description"
+    t.text    "response"
+  end
+
+  create_table "games", force: :cascade do |t|
+    t.integer "chronicle_id"
+    t.integer "game_number"
+    t.string  "title"
   end
 
   create_table "lineages", force: :cascade do |t|


### PR DESCRIPTION
NEEDS DB MIGRATIONS

pls r&r because there's a lot of stuff in here

notes on how it works:
- chronicles now have associated games—you create games within chronicles, e.g. game 1, game 2, game 3, etc. games also have an active status that the STs can check/uncheck to set which games players can submit downtime actions on
- downtime actions are associated w/ a character and a game
  - after characters are set to "active" the player sees a link to downtime actions instead of to edit their sheet
  - players can create downtime actions for active games (usually the current one) and save them in the system; once they hit "save and submit" it makes the action un-editable
- storytellers can see a list of games, and then from that list view the downtimes page for that game
  - each downtime has a "process" link that allows the storytellers to write a response
  - once all responses are complete you can hit the "print downtimes" button at the top of the downtime actions page for that game to print downtime responses really easily

I need to go in real quick and add some permissions stuff but also this is mostly finished
