### PR TITLE
Add simple_format function around text fields

### DIFF
--- a/app/views/characters/show.slim
+++ b/app/views/characters/show.slim
@@ -274,7 +274,7 @@
 			    	= @character.character_type.question1
 			    </a>
 			    <div id="panel1a" class="content">
-			      = @character.answer1
+			      = simple_format(@character.answer1)
 			    </div>
 			  </li>
 			  <li class="accordion-navigation">
@@ -282,7 +282,7 @@
 			    	= @character.character_type.question2
 			    </a>
 			    <div id="panel2a" class="content">
-			      = @character.answer2
+			      = simple_format(@character.answer2)
 			    </div>
 			  </li>
 			  <li class="accordion-navigation">
@@ -290,7 +290,7 @@
 			    	= @character.character_type.question3
 			    </a>
 			    <div id="panel3a" class="content">
-			      = @character.answer3
+			      = simple_format(@character.answer3)
 			    </div>
 			  </li>
 				<li class="accordion-navigation">
@@ -298,7 +298,7 @@
 						= @character.character_type.question4
 					</a>
 					<div id="panel4a" class="content">
-						= @character.answer4
+						= simple_format(@character.answer4)
 					</div>
 				</li>
 				<li class="accordion-navigation">
@@ -306,7 +306,7 @@
 						= @character.character_type.question5
 					</a>
 					<div id="panel5a" class="content">
-						= @character.answer5
+						= simple_format(@character.answer5)
 					</div>
 				</li>
 				<li class="accordion-navigation">
@@ -314,7 +314,7 @@
 						= @character.character_type.question6
 					</a>
 					<div id="panel6a" class="content">
-						= @character.answer6
+						= simple_format(@character.answer6)
 					</div>
 				</li>
 				<li class="accordion-navigation">
@@ -322,7 +322,7 @@
 						= @character.character_type.question7
 					</a>
 					<div id="panel7a" class="content">
-						= @character.answer7
+						= simple_format(@character.answer7)
 					</div>
 				</li>
 				<li class="accordion-navigation">
@@ -330,7 +330,7 @@
 						= @character.character_type.question8
 					</a>
 					<div id="panel8a" class="content">
-						= @character.answer8
+						= simple_format(@character.answer8)
 					</div>
 				</li>
 			</ul>
@@ -338,18 +338,18 @@
 	.row
 		.small-12.columns
 			h2 Wishlist
-			= @character.wishlist
+			= simple_format(@character.wishlist)
 
 	.row
 		.small-12.columns
 			h2 Printed Notes
-			= @character.printed_notes
+			= simple_format(@character.printed_notes)
 
 	- if @character.chronicle.sts.include?(current_user)
 		.row
 			.small-12.columns
 				h2 Storyteller Notes
-				= @character.st_notes
+				= simple_format(@character.st_notes)
 
 	.row
 		.small-12.columns


### PR DESCRIPTION
degen noticed that there was no linebreaks in her carefully-formatted text fields so now there is some!
