### PR TITLE
Switch character show page to use markdown rendering on text fields for more formatting options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem 'jquery-datatables-rails', '~> 3.3.0'
 gem "font-awesome-rails"
 gem "puma"
 gem "foreman"
+gem "redcarpet"
 
 gem 'rails_12factor', group: :production
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,7 @@ GEM
     rake (10.4.2)
     rdoc (4.2.0)
       json (~> 1.4)
+    redcarpet (3.3.2)
     sass (3.4.13)
     sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
@@ -219,6 +220,7 @@ DEPENDENCIES
   puma
   rails (= 4.2.1)
   rails_12factor
+  redcarpet
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   slim-rails

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -60,6 +60,8 @@ class CharactersController < ApplicationController
 		if @character.nil?
 			raise ActionController::RoutingError.new('Not Found')
 		else
+			renderer = Redcarpet::Render::HTML.new(no_links: true, hard_wrap: true, filter_html: true)
+			@markdown = Redcarpet::Markdown.new(renderer, extensions = {})
 			@chronicle = @character.chronicle
 			@mental_skills = Skill.where({skill_category: 1})
 			@physical_skills = Skill.where({skill_category: 2})

--- a/app/views/characters/show.slim
+++ b/app/views/characters/show.slim
@@ -274,7 +274,7 @@
 			    	= @character.character_type.question1
 			    </a>
 			    <div id="panel1a" class="content">
-			      = simple_format(@character.answer1)
+			      = raw @markdown.render(@character.answer1)
 			    </div>
 			  </li>
 			  <li class="accordion-navigation">
@@ -282,7 +282,7 @@
 			    	= @character.character_type.question2
 			    </a>
 			    <div id="panel2a" class="content">
-			      = simple_format(@character.answer2)
+			      = raw @markdown.render(@character.answer2)
 			    </div>
 			  </li>
 			  <li class="accordion-navigation">
@@ -290,7 +290,7 @@
 			    	= @character.character_type.question3
 			    </a>
 			    <div id="panel3a" class="content">
-			      = simple_format(@character.answer3)
+			      = raw @markdown.render(@character.answer3)
 			    </div>
 			  </li>
 				<li class="accordion-navigation">
@@ -298,7 +298,7 @@
 						= @character.character_type.question4
 					</a>
 					<div id="panel4a" class="content">
-						= simple_format(@character.answer4)
+						= raw @markdown.render(@character.answer4)
 					</div>
 				</li>
 				<li class="accordion-navigation">
@@ -306,7 +306,7 @@
 						= @character.character_type.question5
 					</a>
 					<div id="panel5a" class="content">
-						= simple_format(@character.answer5)
+						= raw @markdown.render(@character.answer5)
 					</div>
 				</li>
 				<li class="accordion-navigation">
@@ -314,7 +314,7 @@
 						= @character.character_type.question6
 					</a>
 					<div id="panel6a" class="content">
-						= simple_format(@character.answer6)
+						= raw @markdown.render(@character.answer6)
 					</div>
 				</li>
 				<li class="accordion-navigation">
@@ -322,7 +322,7 @@
 						= @character.character_type.question7
 					</a>
 					<div id="panel7a" class="content">
-						= simple_format(@character.answer7)
+						= raw @markdown.render(@character.answer7)
 					</div>
 				</li>
 				<li class="accordion-navigation">
@@ -330,7 +330,7 @@
 						= @character.character_type.question8
 					</a>
 					<div id="panel8a" class="content">
-						= simple_format(@character.answer8)
+						= raw @markdown.render(@character.answer8)
 					</div>
 				</li>
 			</ul>
@@ -338,18 +338,18 @@
 	.row
 		.small-12.columns
 			h2 Wishlist
-			= simple_format(@character.wishlist)
+			= raw @markdown.render(@character.wishlist)
 
 	.row
 		.small-12.columns
 			h2 Printed Notes
-			= simple_format(@character.printed_notes)
+			= raw @markdown.render(@character.printed_notes)
 
 	- if @character.chronicle.sts.include?(current_user)
 		.row
 			.small-12.columns
 				h2 Storyteller Notes
-				= simple_format(@character.st_notes)
+				= raw @markdown.render(@character.st_notes)
 
 	.row
 		.small-12.columns


### PR DESCRIPTION
Slightly more robust than using simple_format—lets people use markdown formatting to spruce up their text while sanitizing html input.
