### PR TITLE
Split characters into two separate tables in chronicles/show. One for…

### DIFF
--- a/app/assets/javascripts/chronicle.coffee
+++ b/app/assets/javascripts/chronicle.coffee
@@ -3,3 +3,5 @@
 # You can use CoffeeScript in this file: http://coffeescript.org/
 $(document).ready ->
   $("#chronicle_index_table").DataTable()
+  $("#chron_active_chars_table").DataTable()
+  $("#chron_inactive_chars_table").DataTable()

--- a/app/controllers/chronicles_controller.rb
+++ b/app/controllers/chronicles_controller.rb
@@ -39,7 +39,8 @@ class ChroniclesController < ApplicationController
 		if @chronicle.nil?
 			raise ActionController::RoutingError.new('Not Found')
 		else
-			@characters = @chronicle.characters.all
+			@active_characters = @chronicle.characters.where(status: 3)
+			@inactive_characters = @chronicle.characters.where.not(status: 3)
 		end
 	end
 

--- a/app/views/chronicles/show.slim
+++ b/app/views/chronicles/show.slim
@@ -25,8 +25,10 @@
         - else
           = storyteller.full_name
           | , 
-    - if @characters[0]
-      table#character_index_table
+          
+    h3 Active Characters
+    - if @active_characters[0]
+      table#chron_active_chars_table
         thead
           tr
             th Name
@@ -37,7 +39,7 @@
             th 
             th 
         tbody
-          - @characters.each do |character|
+          - @active_characters.each do |character|
             tr
               td
                 = link_to character.name, character_path(character)
@@ -58,4 +60,40 @@
                   = form_tag(character_path(character), method: 'DELETE') do
                     = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to permanently delete this character?");', class: 'button mini-button'
     - else
-     | There are no characters in this chronicle yet!
+      | There are no active characters in this chronicle yet!
+
+    h3 Inactive Characters
+    - if @inactive_characters[0]
+      table#chron_inactive_chars_table
+        thead
+          tr
+            th Name
+            th Player
+            th Affiliation
+            th Lineage
+            th Status
+            th 
+            th 
+        tbody
+          - @inactive_characters.each do |character|
+            tr
+              td
+                = link_to character.name, character_path(character)
+              td
+                = character.user.full_name
+              td
+                - if character.character_type.affiliation.present?
+                  = Affiliation.find_by(id: character.affiliation_id).name
+              td
+                - if character.character_type.lineage.present?
+                  = Lineage.find_by(id: character.lineage_id).name
+              td
+                = get_status(character.status)
+              td
+                = link_to "Edit", edit_character_path(character), class: 'button mini-button'
+              td
+                - if character.user(current_user)
+                  = form_tag(character_path(character), method: 'DELETE') do
+                    = button_tag "Delete", type: 'submit', onClick: 'return confirm("Are you sure you want to permanently delete this character?");', class: 'button mini-button'
+    - else
+     | There are no inactive characters in this chronicle!


### PR DESCRIPTION
… active, one for inactive.

Closes #234 

![screen shot 2016-09-18 at 9 14 39 pm](https://cloud.githubusercontent.com/assets/9502152/18621183/3f1e61dc-7de5-11e6-9a9f-0649b91ee2a1.png)

Upon further discussion with Mark, the former ST who suggested this feature, I came to the conclusion that the character list should instead be split into two different tables. Defaulting to only showing active character will be incredibly annoying during character approval.
